### PR TITLE
fixed bug causing all requests to fail and added pry to gemspec

### DIFF
--- a/holidapi.gemspec
+++ b/holidapi.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'timecop', '~> 0.7'
+  spec.add_development_dependency 'pry', '~> 0.10.1'
 
   spec.add_runtime_dependency 'httparty'
   spec.add_runtime_dependency 'json'

--- a/lib/holidapi.rb
+++ b/lib/holidapi.rb
@@ -5,19 +5,19 @@ require 'holidapi/version'
 
 module HolidApi
   include HTTParty
-  
+
   # Set the base_uri for HTTParty
   base_uri 'http://holidayapi.com/v1'
 
   # Set headers for HTTParty
-  headers({ 
+  headers({
     'User-Agent' => "ruby-holidapi-#{VERSION}",
     'Content-Type' => 'application/json; charset=utf-8',
     'Accept-Encoding' => 'gzip, deflate'
   })
 
   class << self
-    
+
     # Get the holidays from the API.
     # Default country: "US"
     # Default year: Time.now.year
@@ -48,7 +48,7 @@ module HolidApi
     def handle_response(response)
       case response.code.to_i
       when 200
-        JSON.parse(response)['holidays']
+        JSON.parse(response.body)['holidays']
       when 400
         raise BadRequest.new response.parsed_response
       when 401


### PR DESCRIPTION
1. Fixed a bug causing all requests to fail with `TypeError: no implicit conversion of HTTParty::Response into String`
2. Removed unnecessary whitespace
3. Added pry to the gemspec to prevent `bundle exec rspec` from failing
